### PR TITLE
Fix affected version in CVE-2017-100059

### DIFF
--- a/2017/1000xxx/CVE-2017-1000159.json
+++ b/2017/1000xxx/CVE-2017-1000159.json
@@ -17,7 +17,7 @@
                         "version" : {
                            "version_data" : [
                               {
-                                 "version_value" : "3.24.0"
+                                 "version_value" : "Earlier than 3.25.91"
                               }
                            ]
                         }
@@ -36,7 +36,7 @@
       "description_data" : [
          {
             "lang" : "eng",
-            "value" : "Command injection in evince 3.24.8 via filename when printing to PDF"
+            "value" : "Command injection in evince via filename when printing to PDF. This affects versions earlier than 3.25.91."
          }
       ]
    },


### PR DESCRIPTION
Version does 3.24.8 of evince does not exist, see: http://ftp.gnome.org/pub/GNOME/sources/evince/3.24/
Updated versioning based on: 
https://security-tracker.debian.org/tracker/CVE-2017-1000159
https://github.com/GNOME/evince/commit/350404c76dc8601e2cdd2636490e2afc83d3090e