### PR TITLE
CVEs for Zip Slip vulnerable libraries

### DIFF
--- a/2018/1002xxx/CVE-2018-1002200.json
+++ b/2018/1002xxx/CVE-2018-1002200.json
@@ -1,0 +1,68 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@distributedweaknessfiling.org",
+        "DATE_ASSIGNED": "2018-05-17T10:52Z",
+        "ID": "CVE-2018-1002200",
+        "REQUESTER": "danny@snyk.io",
+        "STATE": "PUBLIC",
+        "UPDATED": "2018-05-17T10:52Z"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [{
+                "product": {
+                    "product_data": [{
+                        "product_name": "plexus-archiver",
+                        "version": {
+                            "version_data": [{
+                                "version_affected": "<",
+                                "version_value": "3.6.0"
+                            }]
+                        }
+                    }]
+                },
+                "vendor_name": "Codehaus"
+            }]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [{
+            "lang": "eng",
+            "value": "plexus-archiver before 3.6.0 is vulnerable to directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in an archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'."
+        }]
+    },
+    "problemtype": {
+        "problemtype_data": [{
+            "description": [{
+                "lang": "eng",
+                "value": "CWE-22"
+            }]
+        }]
+    },
+    "references": {
+        "reference_data": [{
+            "name": "https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31680",
+            "refsource": "snyk",
+            "url": "https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31680"
+        }, {
+            "name": "https://snyk.io/research/zip-slip-vulnerability",
+            "refsource": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/snyk/zip-slip-vulnerability",
+            "refsource": "Zip Slip GitHub Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/codehaus-plexus/plexus-archiver/pull/87",
+            "refsource": "github pr",
+            "url": "https://github.com/codehaus-plexus/plexus-archiver/pull/87"
+        }, {
+            "name": "https://github.com/codehaus-plexus/plexus-archiver/commit/f8f4233508193b70df33759ae9dc6154d69c2ea8",
+            "refsource": "github commit",
+            "url": "https://github.com/codehaus-plexus/plexus-archiver/commit/f8f4233508193b70df33759ae9dc6154d69c2ea8"
+        }]
+    }
+}

--- a/2018/1002xxx/CVE-2018-1002201.json
+++ b/2018/1002xxx/CVE-2018-1002201.json
@@ -1,0 +1,64 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@distributedweaknessfiling.org",
+        "DATE_ASSIGNED": "2018-05-17T10:52Z",
+        "ID": "CVE-2018-1002201",
+        "REQUESTER": "danny@snyk.io",
+        "STATE": "PUBLIC",
+        "UPDATED": "2018-05-17T10:52Z"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [{
+                "product": {
+                    "product_data": [{
+                        "product_name": "zt-zip",
+                        "version": {
+                            "version_data": [{
+                                "version_affected": "<",
+                                "version_value": "1.13"
+                            }]
+                        }
+                    }]
+                },
+                "vendor_name": "zeroturnaround"
+            }]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [{
+            "lang": "eng",
+            "value": "zt-zip before 1.13 is vulnerable to directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in a Zip archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'."
+        }]
+    },
+    "problemtype": {
+        "problemtype_data": [{
+            "description": [{
+                "lang": "eng",
+                "value": "CWE-22"
+            }]
+        }]
+    },
+    "references": {
+        "reference_data": [{
+            "name": "https://snyk.io/vuln/SNYK-JAVA-ORGZEROTURNAROUND-31681",
+            "refsource": "snyk",
+            "url": "https://snyk.io/vuln/SNYK-JAVA-ORGZEROTURNAROUND-31681"
+        }, {
+            "name": "https://snyk.io/research/zip-slip-vulnerability",
+            "refsource": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/snyk/zip-slip-vulnerability",
+            "refsource": "Zip Slip GitHub Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff",
+            "refsource": "github commit",
+            "url": "https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff"
+        }]
+    }
+}

--- a/2018/1002xxx/CVE-2018-1002202.json
+++ b/2018/1002xxx/CVE-2018-1002202.json
@@ -1,0 +1,60 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@distributedweaknessfiling.org",
+        "DATE_ASSIGNED": "2018-05-17T10:52Z",
+        "ID": "CVE-2018-1002202",
+        "REQUESTER": "danny@snyk.io",
+        "STATE": "PUBLIC",
+        "UPDATED": "2018-05-17T10:52Z"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [{
+                "product": {
+                    "product_data": [{
+                        "product_name": "zip4j",
+                        "version": {
+                            "version_data": [{
+                                "version_affected": "<",
+                                "version_value": "1.3.3"
+                            }]
+                        }
+                    }]
+                },
+                "vendor_name": "zip4j"
+            }]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [{
+            "lang": "eng",
+            "value": "zip4j before 1.3.3 is vulnerable to directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in a Zip archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'."
+        }]
+    },
+    "problemtype": {
+        "problemtype_data": [{
+            "description": [{
+                "lang": "eng",
+                "value": "CWE-22"
+            }]
+        }]
+    },
+    "references": {
+        "reference_data": [{
+            "name": "https://snyk.io/vuln/SNYK-JAVA-NETLINGALAZIP4J-31679",
+            "refsource": "snyk",
+            "url": "https://snyk.io/vuln/SNYK-JAVA-NETLINGALAZIP4J-31679"
+        }, {
+            "name": "https://snyk.io/research/zip-slip-vulnerability",
+            "refsource": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/snyk/zip-slip-vulnerability",
+            "refsource": "Zip Slip GitHub Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }]
+    }
+}

--- a/2018/1002xxx/CVE-2018-1002203.json
+++ b/2018/1002xxx/CVE-2018-1002203.json
@@ -1,0 +1,68 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@distributedweaknessfiling.org",
+        "DATE_ASSIGNED": "2018-05-17T10:52Z",
+        "ID": "CVE-2018-1002203",
+        "REQUESTER": "danny@snyk.io",
+        "STATE": "PUBLIC",
+        "UPDATED": "2018-05-17T10:52Z"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [{
+                "product": {
+                    "product_data": [{
+                        "product_name": "unzipper",
+                        "version": {
+                            "version_data": [{
+                                "version_affected": "<",
+                                "version_value": "0.8.13"
+                            }]
+                        }
+                    }]
+                },
+                "vendor_name": "node.js"
+            }]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [{
+            "lang": "eng",
+            "value": "unzipper npm library before 0.8.13 is vulnerable to directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in a Zip archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'."
+        }]
+    },
+    "problemtype": {
+        "problemtype_data": [{
+            "description": [{
+                "lang": "eng",
+                "value": "CWE-22"
+            }]
+        }]
+    },
+    "references": {
+        "reference_data": [{
+            "name": "https://snyk.io/vuln/npm:unzipper:20180415",
+            "refsource": "snyk",
+            "url": "https://snyk.io/vuln/npm:unzipper:20180415"
+        }, {
+            "name": "https://snyk.io/research/zip-slip-vulnerability",
+            "refsource": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/snyk/zip-slip-vulnerability",
+            "refsource": "Zip Slip GitHub Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/ZJONSSON/node-unzipper/pull/59",
+            "refsource": "github pr",
+            "url": "https://github.com/ZJONSSON/node-unzipper/pull/59"
+        }, {
+            "name": "https://github.com/ZJONSSON/node-unzipper/commit/2220ddd5b58f6252069a4f99f9475441ad0b50cd",
+            "refsource": "github commit",
+            "url": "https://github.com/ZJONSSON/node-unzipper/commit/2220ddd5b58f6252069a4f99f9475441ad0b50cd"
+        }]
+    }
+}

--- a/2018/1002xxx/CVE-2018-1002204.json
+++ b/2018/1002xxx/CVE-2018-1002204.json
@@ -1,0 +1,68 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@distributedweaknessfiling.org",
+        "DATE_ASSIGNED": "2018-05-17T10:52Z",
+        "ID": "CVE-2018-1002204",
+        "REQUESTER": "danny@snyk.io",
+        "STATE": "PUBLIC",
+        "UPDATED": "2018-05-17T10:52Z"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [{
+                "product": {
+                    "product_data": [{
+                        "product_name": "adm-zip",
+                        "version": {
+                            "version_data": [{
+                                "version_affected": "<",
+                                "version_value": "0.4.9"
+                            }]
+                        }
+                    }]
+                },
+                "vendor_name": "node.js"
+            }]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [{
+            "lang": "eng",
+            "value": "adm-zip npm library before 0.4.9 is vulnerable to directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in a Zip archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'."
+        }]
+    },
+    "problemtype": {
+        "problemtype_data": [{
+            "description": [{
+                "lang": "eng",
+                "value": "CWE-22"
+            }]
+        }]
+    },
+    "references": {
+        "reference_data": [{
+            "name": "https://snyk.io/vuln/npm:adm-zip:20180415",
+            "refsource": "snyk",
+            "url": "https://snyk.io/vuln/npm:adm-zip:20180415"
+        }, {
+            "name": "https://snyk.io/research/zip-slip-vulnerability",
+            "refsource": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/snyk/zip-slip-vulnerability",
+            "refsource": "Zip Slip GitHub Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/cthackers/adm-zip/pull/212",
+            "refsource": "github pr",
+            "url": "https://github.com/cthackers/adm-zip/pull/212"
+        }, {
+            "name": "https://github.com/cthackers/adm-zip/commit/62f64004fefb894c523a7143e8a88ebe6c84df25",
+            "refsource": "github commit",
+            "url": "https://github.com/cthackers/adm-zip/commit/62f64004fefb894c523a7143e8a88ebe6c84df25"
+        }]
+    }
+}

--- a/2018/1002xxx/CVE-2018-1002205.json
+++ b/2018/1002xxx/CVE-2018-1002205.json
@@ -1,0 +1,68 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@distributedweaknessfiling.org",
+        "DATE_ASSIGNED": "2018-05-17T10:52Z",
+        "ID": "CVE-2018-1002205",
+        "REQUESTER": "danny@snyk.io",
+        "STATE": "PUBLIC",
+        "UPDATED": "2018-05-17T10:52Z"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [{
+                "product": {
+                    "product_data": [{
+                        "product_name": "DotNetZip.Semvered",
+                        "version": {
+                            "version_data": [{
+                                "version_affected": "<",
+                                "version_value": "1.11.0"
+                            }]
+                        }
+                    }]
+                },
+                "vendor_name": "DotNetZip"
+            }]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [{
+            "lang": "eng",
+            "value": "DotNetZip.Semvered before 1.11.0 is vulnerable to directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in a Zip archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'."
+        }]
+    },
+    "problemtype": {
+        "problemtype_data": [{
+            "description": [{
+                "lang": "eng",
+                "value": "CWE-22"
+            }]
+        }]
+    },
+    "references": {
+        "reference_data": [{
+            "name": "https://snyk.io/vuln/SNYK-DOTNET-DOTNETZIP-60245",
+            "refsource": "snyk",
+            "url": "https://snyk.io/vuln/SNYK-DOTNET-DOTNETZIP-60245"
+        }, {
+            "name": "https://snyk.io/research/zip-slip-vulnerability",
+            "refsource": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/snyk/zip-slip-vulnerability",
+            "refsource": "Zip Slip GitHub Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/haf/DotNetZip.Semverd/pull/121",
+            "refsource": "github pr",
+            "url": "https://github.com/haf/DotNetZip.Semverd/pull/121"
+        }, {
+            "name": "https://github.com/haf/DotNetZip.Semverd/commit/55d2c13c0cc64654e18fcdd0038fdb3d7458e366",
+            "refsource": "github commit",
+            "url": "https://github.com/haf/DotNetZip.Semverd/commit/55d2c13c0cc64654e18fcdd0038fdb3d7458e366"
+        }]
+    }
+}

--- a/2018/1002xxx/CVE-2018-1002206.json
+++ b/2018/1002xxx/CVE-2018-1002206.json
@@ -1,0 +1,68 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@distributedweaknessfiling.org",
+        "DATE_ASSIGNED": "2018-05-17T10:52Z",
+        "ID": "CVE-2018-1002206",
+        "REQUESTER": "danny@snyk.io",
+        "STATE": "PUBLIC",
+        "UPDATED": "2018-05-17T10:52Z"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [{
+                "product": {
+                    "product_data": [{
+                        "product_name": "SharpCompress",
+                        "version": {
+                            "version_data": [{
+                                "version_affected": "<",
+                                "version_value": "0.21.0"
+                            }]
+                        }
+                    }]
+                },
+                "vendor_name": "SharpCompress"
+            }]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [{
+            "lang": "eng",
+            "value": "SharpCompress before 0.21.0 is vulnerable to directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in a Zip archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'."
+        }]
+    },
+    "problemtype": {
+        "problemtype_data": [{
+            "description": [{
+                "lang": "eng",
+                "value": "CWE-22"
+            }]
+        }]
+    },
+    "references": {
+        "reference_data": [{
+            "name": "https://snyk.io/vuln/SNYK-DOTNET-SHARPCOMPRESS-60246",
+            "refsource": "snyk",
+            "url": "https://snyk.io/vuln/SNYK-DOTNET-SHARPCOMPRESS-60246"
+        }, {
+            "name": "https://snyk.io/research/zip-slip-vulnerability",
+            "refsource": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/snyk/zip-slip-vulnerability",
+            "refsource": "Zip Slip GitHub Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/adamhathcock/sharpcompress/pull/374",
+            "refsource": "github pr",
+            "url": "https://github.com/adamhathcock/sharpcompress/pull/374"
+        }, {
+            "name": "https://github.com/adamhathcock/sharpcompress/commit/42b1205fb435de523e6ef8ac5b7bafbe712997f6",
+            "refsource": "github commit",
+            "url": "https://github.com/adamhathcock/sharpcompress/commit/42b1205fb435de523e6ef8ac5b7bafbe712997f6"
+        }]
+    }
+}

--- a/2018/1002xxx/CVE-2018-1002207.json
+++ b/2018/1002xxx/CVE-2018-1002207.json
@@ -1,0 +1,68 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@distributedweaknessfiling.org",
+        "DATE_ASSIGNED": "2018-05-17T10:52Z",
+        "ID": "CVE-2018-1002207",
+        "REQUESTER": "danny@snyk.io",
+        "STATE": "PUBLIC",
+        "UPDATED": "2018-05-17T10:52Z"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [{
+                "product": {
+                    "product_data": [{
+                        "product_name": "archiver",
+                        "version": {
+                            "version_data": [{
+                                "version_affected": "<",
+                                "version_value": "e4ef56d48eb029648b0e895bb0b6a393ef0829c3"
+                            }]
+                        }
+                    }]
+                },
+                "vendor_name": "golang"
+            }]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [{
+            "lang": "eng",
+            "value": "mholt/archiver golang package before e4ef56d48eb029648b0e895bb0b6a393ef0829c3 is vulnerable to directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in an archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'."
+        }]
+    },
+    "problemtype": {
+        "problemtype_data": [{
+            "description": [{
+                "lang": "eng",
+                "value": "CWE-22"
+            }]
+        }]
+    },
+    "references": {
+        "reference_data": [{
+            "name": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMMHOLTARCHIVERCMDARCHIVER-50071",
+            "refsource": "snyk",
+            "url": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMMHOLTARCHIVERCMDARCHIVER-50071"
+        }, {
+            "name": "https://snyk.io/research/zip-slip-vulnerability",
+            "refsource": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/snyk/zip-slip-vulnerability",
+            "refsource": "Zip Slip GitHub Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/mholt/archiver/pull/65",
+            "refsource": "github pr",
+            "url": "https://github.com/mholt/archiver/pull/65"
+        }, {
+            "name": "https://github.com/mholt/archiver/commit/e4ef56d48eb029648b0e895bb0b6a393ef0829c3",
+            "refsource": "github commit",
+            "url": "https://github.com/mholt/archiver/commit/e4ef56d48eb029648b0e895bb0b6a393ef0829c3"
+        }]
+    }
+}

--- a/2018/1002xxx/CVE-2018-1002208.json
+++ b/2018/1002xxx/CVE-2018-1002208.json
@@ -1,0 +1,64 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@distributedweaknessfiling.org",
+        "DATE_ASSIGNED": "2018-05-17T10:52Z",
+        "ID": "CVE-2018-1002208",
+        "REQUESTER": "danny@snyk.io",
+        "STATE": "PUBLIC",
+        "UPDATED": "2018-06-11T10:52Z"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [{
+                "product": {
+                    "product_data": [{
+                        "product_name": "sharplibzip",
+                        "version": {
+                            "version_data": [{
+                                "version_affected": ">",
+                                "version_value": "0"
+                            }]
+                        }
+                    }]
+                },
+                "vendor_name": "sharplibzip"
+            }]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [{
+            "lang": "eng",
+            "value": "sharplibzip is vulnerable to directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in a Zip archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'."
+        }]
+    },
+    "problemtype": {
+        "problemtype_data": [{
+            "description": [{
+                "lang": "eng",
+                "value": "CWE-22"
+            }]
+        }]
+    },
+    "references": {
+        "reference_data": [{
+            "name": "https://snyk.io/vuln/SNYK-DOTNET-SHARPZIPLIB-60247",
+            "refsource": "snyk",
+            "url": "https://snyk.io/vuln/SNYK-DOTNET-SHARPZIPLIB-60247"
+        }, {
+            "name": "https://github.com/icsharpcode/SharpZipLib/issues/232",
+            "refsource": "GitHub Issue",
+            "url": "https://github.com/icsharpcode/SharpZipLib/issues/232"
+        }, {
+            "name": "https://snyk.io/research/zip-slip-vulnerability",
+            "refsource": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/snyk/zip-slip-vulnerability",
+            "refsource": "Zip Slip GitHub Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }]
+    }
+}

--- a/2018/1002xxx/CVE-2018-1002209.json
+++ b/2018/1002xxx/CVE-2018-1002209.json
@@ -1,0 +1,60 @@
+{
+    "CVE_data_meta": {
+        "ASSIGNER": "cve-assign@distributedweaknessfiling.org",
+        "DATE_ASSIGNED": "2018-06-14T10:52Z",
+        "ID": "CVE-2018-1002209",
+        "REQUESTER": "danny@snyk.io",
+        "STATE": "PUBLIC",
+        "UPDATED": "2018-06-14T10:52Z"
+    },
+    "affects": {
+        "vendor": {
+            "vendor_data": [{
+                "product": {
+                    "product_data": [{
+                        "product_name": "quazip",
+                        "version": {
+                            "version_data": [{
+                                "version_affected": "<",
+                                "version_value": "0.7.6"
+                            }]
+                        }
+                    }]
+                },
+                "vendor_name": "quazip"
+            }]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+        "description_data": [{
+            "lang": "eng",
+            "value": "QuaZIP before 0.7.6 is vulnerable to directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in a Zip archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'."
+        }]
+    },
+    "problemtype": {
+        "problemtype_data": [{
+            "description": [{
+                "lang": "eng",
+                "value": "CWE-22"
+            }]
+        }]
+    },
+    "references": {
+        "reference_data": [{
+            "name": "https://github.com/stachenov/quazip/commit/5d2fc16a1976e5bf78d2927b012f67a2ae047a98",
+            "refsource": "GitHub Commit",
+            "url": "https://github.com/stachenov/quazip/commit/5d2fc16a1976e5bf78d2927b012f67a2ae047a98"
+        }, {
+            "name": "https://snyk.io/research/zip-slip-vulnerability",
+            "refsource": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }, {
+            "name": "https://github.com/snyk/zip-slip-vulnerability",
+            "refsource": "Zip Slip GitHub Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }]
+    }
+}


### PR DESCRIPTION
Product | Language | Confirmed vulnerable | Fixed Version | CVE
-- | -- | -- | -- | --
unzipper | JavaScript | YES | 0.8.13 | CVE-2018-1002203
adm-zip | JavaScript | YES | 0.4.9 | CVE-2018-1002204
codehaus/plexus-archiver | Java | YES | 3.6.0 | CVE-2018-1002200
zeroturnaround/zt-zip | Java | YES | 1.13 | CVE-2018-1002201
zip4j | Java | YES | 1.3.3  | CVE-2018-1002202
DotNetZip.Semverd | C#| YES | 1.11.0 | CVE-2018-1002205
SharpCompress | C# | YES | 0.21.0 | CVE-2018-1002206
mholt/archiver | Go | YES | e4ef56d4 | CVE-2018-1002207
SharpZipLib | C# | YES |  | CVE-2018-1002208
quazip | C++ | YES | 0.7.6 | CVE-2018-1002209

